### PR TITLE
[ADDED] Push.co Notification Support (iOS Devices)

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -44,11 +44,11 @@ if (!$notification_config->is_empty()) {
 
     // Check if rapidpush notification is enabled.
     $rapidpush_enabled = false;
-    $api_key = '';
+    $rapidpush_api_key = '';
     if ($notification_config->get_value('enable_rapidpush')) {
         require 'includes/RapidPush.class.php';
-        $api_key = $notification_config->get_value('rapidpush_apikey');
-        if (!empty($api_key)) {
+        $rapidpush_api_key = $notification_config->get_value('rapidpush_apikey');
+        if (!empty($rapidpush_api_key)) {
             $rapidpush_enabled = true;
         }
     }
@@ -392,7 +392,7 @@ if (!$notification_config->is_empty()) {
             try {
                 // Send rapidpush notification if enabled.
                 if ($rapidpush_enabled) {
-                    $rp = new RapidPush($api_key);
+                    $rp = new RapidPush($rapidpush_api_key);
                     $rp->notify('PHPMiner error', $data);
                 }
             }

--- a/cron.php
+++ b/cron.php
@@ -262,7 +262,7 @@ if (!$notification_config->is_empty()) {
                                     if (!isset($notifications['temp_min'][$rig])) {
                                         $notifications['temp_min'][$rig] = array();
                                     }
-                                    $notifications['temp_min'][$rig][$gpu_id] = 'Rig ' . $rig . ' : GPU Temperatur on GPU ' . $gpu_id . ' (' . $gpu_name . ') is to low. Current value: ' . $device['gpu_info']['Temperature'] . ' min: ' . $device['notify_config']['temperature']['min'];
+                                    $notifications['temp_min'][$rig][$gpu_id] = 'Rig ' . $rig . ' : GPU Temperature on GPU ' . $gpu_id . ' (' . $gpu_name . ') is to low. Current value: ' . $device['gpu_info']['Temperature'] . ' min: ' . $device['notify_config']['temperature']['min'];
                                 }
                             }
                             else {
@@ -279,7 +279,7 @@ if (!$notification_config->is_empty()) {
                                     if (!isset($notifications['temp_max'][$rig])) {
                                         $notifications['temp_max'][$rig] = array();
                                     }
-                                    $notifications['temp_max'][$rig][$gpu_id] = 'Rig ' . $rig . ' : GPU Temperatur on GPU ' . $gpu_id . ' (' . $gpu_name . ') is to high. Current value: ' . $device['gpu_info']['Temperature'] . ' max: ' . $device['notify_config']['temperature']['max'];
+                                    $notifications['temp_max'][$rig][$gpu_id] = 'Rig ' . $rig . ' : GPU Temperature on GPU ' . $gpu_id . ' (' . $gpu_name . ') is to high. Current value: ' . $device['gpu_info']['Temperature'] . ' max: ' . $device['notify_config']['temperature']['max'];
                                 }
                             }
                             else {

--- a/cron.php
+++ b/cron.php
@@ -390,7 +390,7 @@ if (!$notification_config->is_empty()) {
                 // Send custom post notification if enabled.
                 if ($post_enabled) {
                     $http = new HttpClient();
-                    $http->do_get($post_url, array(
+                    $http->do_post($post_url, array(
                         'type' => $type,
                         'msg' => $data,
                     ));

--- a/phpminer_rpcclient/index.php
+++ b/phpminer_rpcclient/index.php
@@ -47,7 +47,7 @@ function get_cgminer_pid() {
         }
         return false;
     } else {
-        $res = trim(shell_exec("ps a | grep \"cgminer -c\" | grep -v grep | grep -v SCREEN | grep -v \"php -f \" | awk '{print $1}'"));
+        $res = trim(shell_exec("ps a | grep \"cgminer -\" | grep -v grep | grep -v SCREEN | grep -v \"php -f \" | awk '{print $1}'"));
         return $res;
     }
 }

--- a/views/notify/settings.tpl.php
+++ b/views/notify/settings.tpl.php
@@ -20,6 +20,18 @@
                         <td class="value"><input type="text" id="rapidpush_apikey" name="rapidpush_apikey" value="<?php echo (!empty($conf['rapidpush_apikey']) ? $conf['rapidpush_apikey'] : '');?>" /></td>
                     </tr>
                     <tr>
+                        <td class="key">Enable Push.co notifications:<i data-toggle="tooltip" title="Push.co is an iOS push notification service, if you enable it and provide valid API details you will recieve rig problems instantly on your iOS device." class="icon-help-circled"></i></td>
+                        <td class="value"><div class="slider"><input type="checkbox" id="pushco_enable" name="pushco_enable" value="1" <?php echo (isset($conf['pushco_enable']) && $conf['pushco_enable'] == "1" ? 'checked="checked"' : '');?> /><label for="pushco_enable"></label></div></td>
+                    </tr>
+                    <tr>
+                        <td class="key"><label for="pushco_api_key">Push.co API-Key:</label><i data-toggle="tooltip" title="Get your Developer Keys details at http://push.co/apps under Developer Tab" class="icon-help-circled"></i></td>
+                        <td class="value"><input type="text" id="pushco_api_key" name="pushco_api_key" value="<?php echo (!empty($conf['pushco_api_key']) ? $conf['pushco_api_key'] : '');?>" /></td>
+                    </tr>
+                    <tr>
+                        <td class="key"><label for="pushco_api_secret">Push.co API-Secret:</label><i data-toggle="tooltip" title="Get your Developer Keys details at http://push.co/apps under Developer Tab" class="icon-help-circled"></i></td>
+                        <td class="value"><input type="text" id="pushco_api_secret" name="pushco_api_secret" value="<?php echo (!empty($conf['pushco_api_secret']) ? $conf['pushco_api_secret'] : '');?>" /></td>
+                    </tr>
+                    <tr>
                         <td class="key">Enable E-Mail notifications:</td>
                         <td class="value"><div class="slider"><input type="checkbox" id="enable_email" name="enable_email" value="1" <?php echo (isset($conf['enable_email']) && $conf['enable_email'] == "1" ? 'checked="checked"' : '');?> /><label for="enable_email"></label></div></td>
                     </tr>


### PR DESCRIPTION
Added support for Push.co notifications.
Setup is the same as RapidPush, just set API details and enable it from "Notifications / Auto Tasks"

Also a few fixes were added:
[FIX] POST Notification, do POST instead of GET request
[FIX] BAMT/SMOS Compatibility, cgminer start command does not necessarily have ‘-c’ or ‘--config’ as
first arg, used in PID parsing.
[FIX] Typo, GPU Temperature notification
