### PR TITLE
Fix cron job that does not start

### DIFF
--- a/linux_setup.sh
+++ b/linux_setup.sh
@@ -98,7 +98,7 @@ echo "chown $APACHE_USER:$APACHE_GROUP $PHPMINER_DB_CFG_PATH" | sh
 echo "Install cronjob."
 echo "# /etc/cron.d/phpminer: crontab fragment for phpminer" > /etc/cron.d/phpminer
 echo "#  This will run the cronjob script for phpminer to send notifications and other periodic tasks." >> /etc/cron.d/phpminer
-echo "* * * * * $APACHE_USER php -f $PHPMINER_PATH/cron.php" >>  /etc/cron.d/phpminer
+echo "* * * * * $APACHE_USER cd $PHPMINER_PATH/; php -f cron.php" >>  /etc/cron.d/phpminer
 
 # Install apache vhost
 echo "Install apache2 vhost."


### PR DESCRIPTION
needs to cd into miner path to execute php cron.
If not, db class cannot be found.
